### PR TITLE
Fix: Add support to Gatsby ^2.24.33

### DIFF
--- a/src/static-query.js
+++ b/src/static-query.js
@@ -83,9 +83,14 @@ function getQueryHashForComponentPath(componentPath) {
 }
 
 function getQueryResult(hash) {
-  const queryDataFileName = `public/static/d/${hash}.json`;
+  const queryDataFileNameLegacy = `public/static/d/${hash}.json`;
+  // Gatsby ^v2.24.33
+  const queryDataFileName = `public/page-data/sq/d/${hash}.json`;
 
-  if (existsSync(queryDataFileName)) {
+  if (existsSync(queryDataFileNameLegacy)) {
+    return JSON.parse(readFileSync(queryDataFileNameLegacy));
+  }
+  else if (existsSync(queryDataFileName)) {
     return JSON.parse(readFileSync(queryDataFileName));
   } else {
     if (existsSync("public")) {


### PR DESCRIPTION
Hellor @ehrencrona,

**Context:** Since Gatsby version 2.24.33, the StaticQueries directory has changed, causing failures when trying to load staticQueries into the test stage. Issue link: https://github.com/ehrencrona/gatsby-plugin-testing/issues/1

This PR works on both old and new versions, but if necessary, a tag can be created to signal a significant change.

I humbly suggest this change @ehrencrona, I would like to know if this change is a valid contribution to your project and your opinion about the change.

Thanks.