### PR TITLE
Add missing path separator

### DIFF
--- a/src/static-query.js
+++ b/src/static-query.js
@@ -85,7 +85,7 @@ function getQueryHashForComponentPath(componentPath) {
 }
 
 function getQueryResult(hash) {
-  const queryDataFileNameLegacy = join("public", "static", `d${hash}.json`);
+  const queryDataFileNameLegacy = join("public", "static", `d/${hash}.json`);
   // Gatsby ^v2.24.33
   const queryDataFileName = join("public", "page-data", "sq", `d/${hash}.json`);
 


### PR DESCRIPTION
The path used for legacy Gatsby version is wrong as a separator is missing.